### PR TITLE
fix: an issue caused by Chrome iOS in the iframe.

### DIFF
--- a/sysend.js
+++ b/sysend.js
@@ -124,7 +124,7 @@
     }
     if (is_iframe()) {
       window.addEventListener('message', function(e) {
-          var payload
+          var payload;
           try {
               payload = JSON.parse(e.data);
           } finally {

--- a/sysend.js
+++ b/sysend.js
@@ -124,17 +124,15 @@
     }
     if (is_iframe()) {
       window.addEventListener('message', function(e) {
-          if (typeof e.data !== 'string') return;
-          var isValidJSON = false;
-          var payload;
+          var payload
           try {
               payload = JSON.parse(e.data);
-              isValidJSON = true;
           } catch (error) {
-              isValidJSON = false;
-          }
-          if (isValidJSON && payload.name === uniq_prefix) {
-              sysend.broadcast(payload.key, payload.data);
+              payload = {};
+          } finally {
+              if (payload && payload.name === uniq_prefix) {
+                  sysend.broadcast(payload.key, payload.data);
+              }
           }
       });
     }

--- a/sysend.js
+++ b/sysend.js
@@ -127,8 +127,6 @@
           var payload
           try {
               payload = JSON.parse(e.data);
-          } catch (error) {
-              payload = {};
           } finally {
               if (payload && payload.name === uniq_prefix) {
                   sysend.broadcast(payload.key, payload.data);

--- a/sysend.js
+++ b/sysend.js
@@ -124,8 +124,16 @@
     }
     if (is_iframe()) {
       window.addEventListener('message', function(e) {
-          var payload = JSON.parse(e.data);
-          if (payload.name === uniq_prefix) {
+          if (typeof e.data !== 'string') return;
+          var isValidJSON = false;
+          var payload;
+          try {
+              payload = JSON.parse(e.data);
+              isValidJSON = true;
+          } catch (error) {
+              isValidJSON = false;
+          }
+          if (isValidJSON && payload.name === uniq_prefix) {
               sysend.broadcast(payload.key, payload.data);
           }
       });


### PR DESCRIPTION
Chrome iOS will send a built-in message in the iframe with type equal "org.chromium.encryptedMessage", containing an object type variable in the event.data field as below:
{
  "type": "org.chromium.encryptedMessage",
  "message_payload": {
    ...
  }
 ...
}

It only happened on Chrome iOS.