### PR TITLE
Adds validation for the storage event key

### DIFF
--- a/sysend.js
+++ b/sysend.js
@@ -601,7 +601,7 @@
         }
         window.addEventListener('storage', function(e) {
             // prevent event to be executed on remove in IE
-            if (e.key.match(re) && index++ % 2 === 0) {
+            if (e.key && e.key.match(re) && index++ % 2 === 0) {
                 var key = e.key.replace(re, '');
                 if (callbacks[key]) {
                     var value = e.newValue || get(key);


### PR DESCRIPTION
Clearing the local storage in Chrome triggers a storage event with a null value key. This causes an error when trying to access the match method.
This adds basic validation to prevent that from happening.
![image](https://user-images.githubusercontent.com/85087316/229712471-ce9980cd-3de7-4dd7-b2b0-f8a798fa3235.png)
